### PR TITLE
Add support for direct play via URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ spotify-cli play --track "the less i know the better"
 spotify-cli play --artist "still woozy"
 spotify-cli play --album "testing"
 spotify-cli play --playlist "release radar"
+spotify-cli play --uri "spotify:album:27ftYHLeunzcSzb33Wk1hf"
 ```
 
 Navigate playback

--- a/spotify-cli.go
+++ b/spotify-cli.go
@@ -221,7 +221,7 @@ func handlePlay(c *cli.Context) error {
 		Spotify.PlayURI(uri)
 
 	case uri != "":
-		suri:= Spotify.SpotifyURI(uri)
+		suri:= spotify.SpotifyURI(uri)
 		Spotify.PlayURI(suri)
 
 	default:

--- a/spotify-cli.go
+++ b/spotify-cli.go
@@ -38,6 +38,7 @@ func main() {
 				&cli.StringFlag{Name: "track", Aliases: []string{"t"}, Usage: "A track to play."},
 				&cli.StringFlag{Name: "album", Aliases: []string{"m"}, Usage: "An album to play."},
 				&cli.StringFlag{Name: "artist", Aliases: []string{"r"}, Usage: "An artist to play."},
+				&cli.StringFlag{Name: "uri", Aliases: []string{"u"}, Usage: "Anything, by using spotify uri.(format: spotify:<type>:<id>)"},
 				&cli.StringFlag{Name: "playlist", Aliases: []string{"l"}, Usage: "An playlist to play."},
 			},
 		},
@@ -184,6 +185,7 @@ func handlePlay(c *cli.Context) error {
 	album := c.String("album")
 	artist := c.String("artist")
 	playlist := c.String("playlist")
+	uri:= c.String("uri")
 
 	switch true {
 	case device != "":
@@ -216,6 +218,9 @@ func handlePlay(c *cli.Context) error {
 
 	case playlist != "":
 		uri := Spotify.SimpleSearch(playlist, "playlist")
+		Spotify.PlayURI(uri)
+
+	case uri != "":
 		Spotify.PlayURI(uri)
 
 	default:

--- a/spotify-cli.go
+++ b/spotify-cli.go
@@ -221,7 +221,8 @@ func handlePlay(c *cli.Context) error {
 		Spotify.PlayURI(uri)
 
 	case uri != "":
-		Spotify.PlayURI(uri)
+		suri:= SpotifyURI(uri)
+		Spotify.PlayURI(suri)
 
 	default:
 		Spotify.Play()

--- a/spotify-cli.go
+++ b/spotify-cli.go
@@ -221,7 +221,7 @@ func handlePlay(c *cli.Context) error {
 		Spotify.PlayURI(uri)
 
 	case uri != "":
-		suri:= SpotifyURI(uri)
+		suri:= Spotify.SpotifyURI(uri)
 		Spotify.PlayURI(suri)
 
 	default:


### PR DESCRIPTION
Added a --uri parameter option to the play command to allow for direct playing of artists/albums/tracks/playlists.